### PR TITLE
Fix wrong DEBUG and TEMPLATE_DEBUG checks

### DIFF
--- a/prodready/management/commands/is_it_ready.py
+++ b/prodready/management/commands/is_it_ready.py
@@ -42,10 +42,10 @@ class Validations(object):
 
     def check_debug_values(self):
         messages = []
-        if not settings.DEBUG:
+        if settings.DEBUG:
             messages.append('Set DEBUG to False')
 
-        if not settings.TEMPLATE_DEBUG:
+        if settings.TEMPLATE_DEBUG:
             messages.append('Set TEMPLATE_DEBUG to False')
 
         if settings.DEBUG_PROPAGATE_EXCEPTIONS:


### PR DESCRIPTION
The checks were inverted and were instead checking if
the settings are false instead of true